### PR TITLE
Created middleware and updated put/delete/post requests to need login

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -2,15 +2,48 @@ const Project = require('../model/projects');
 const User = require('../model/users');
 const passport = require("passport");
 
+
+function checkBodyForProperties (body) {
+
+  // remove id and owner - these should be unable to be updated from put
+  const {id, title, owner, ...rest } = body;
+  
+  // spread title and rest of the object into new obeject ready to be saved
+  const newObj = {
+  	title,
+   	...rest
+  };
+  
+  return newObj;
+}
+
+
+
 module.exports = function(router) {
+
+    // All routes except GET are protected
+
+    router.use(function(req, res, next) {
+
+      // get requests allowse
+        if (req.method === "GET") {
+         return next();
+        }
+  
+        // if req.user does not exist for POST || PUT || DELETE redirect
+        if (!req.user) {
+          return res.status(400).json({message: 'You have to be loggedin to access this route.'});
+        }
+        
+        // user is logged in move to next step
+        return next();
+     }) 
+
 
     // This route is just for checking if '/api' route is working
     router.get('/', function(req, res) {
       res.json({ message: 'API Initialized!'});
     });
-
-
-
 
     // PROJECT ROUTES
 
@@ -87,28 +120,56 @@ module.exports = function(router) {
     })
     // The put updates project based on the ID passed to the route
     .put(function(req, res) {
-     Project.findById(req.params.project_id, function(err, project) {
-       if (err) { res.send(err); }
-       if (project) {
-        project = setProjectObj(req.body, project)
-        //save project
-        project.save(function(err) {
+
+      // Search for user to check whether they own the project
+      User.findById(req.user._id)
+      .exec(function (err, user) {
+        // user does not own project cannot update it
+        if (!user.projects.includes(req.params.project_id)) return res.json({message: "Cannot update project you do now own."});
+        
+        // user owns project
+        Project.findById(req.params.project_id, function(err, project) {
           if (err) { res.send(err); }
-          res.json({ message: 'Project has been updated' });
+          if (project) {
+
+            // check project for title (required field) 
+            if (!req.body.title) return res.json({ message: 'Title is required'});
+
+            // filter project so certain values are protected
+            const projectUpdate = checkBodyForProperties(req.body);
+            
+            // updates current document with new values
+            project.update(projectUpdate)
+              .exec(function (err, doc) {
+                  if (err) { res.send(err); }
+                  console.log(doc, 'this is doc')
+                  return res.json({ message: 'Project has been updated' });
+              }) 
+          } else {
+            res.json({ message: "Project not found by the id... no action performed" });
+          }
         });
-       } else {
-         res.json({ message: "Project not found by the id... no action performed" });
-       }
-     });
+      })
     })
     //delete method for removing a project from our database
     .delete(function(req, res) {
      //selects the project by its ID, then removes it.
      console.log('delete requested', req.params.project_id);
-     Project.remove({ _id: req.params.project_id }, function(err, project) {
-       if (err) { res.send(err); }
-       res.json({ message: 'Project has been deleted' })
-     })
+
+    // Check whether loggedin user owns the project
+      User.findById(req.user._id)
+        .exec(function (err, user) {
+          
+          // user does not own project reject request
+          if (!user) return res.status(400).json({message: 'User does not exist'});
+          // check whether users created projects includes the project id
+          user.projects.includes(req.params.project_id) 
+            ? Project.remove({ _id: req.params.project_id }, function(err, project) {
+                if (err) { res.send(err); }
+                return res.json({ message: 'Project has been deleted' })
+              })
+            : res.status(400).json({message: 'You do not own that project'});     
+        });
     });
 
     // USER ROUTES
@@ -141,40 +202,40 @@ module.exports = function(router) {
         else { res.json(user); }
       });
     })
+
     // The put updates user based on the ID passed to the route
     .put(function(req, res) {
-    User.findById(req.params.user_id, function(err, user) {
-      console.log(user);
-      if (err) { res.send(err); }
-      if (user) {
-        user = setUserObj(req.body, user);
-        //save user
-        user.save(function(err) {
-          if (err) { res.send(err); }
-          res.json({ message: 'User has been updated'});
-        });
-      } else {
-        res.json({ message: 'User not found by id... no action performed'});
-      }
+      User.findById(req.params.user_id, function(err, user) {
+        if (err) return res.send(err);
+        if (!user._id.equals(req.user._id)) return res.json({message: 'User details do not match.'})
+        if (user) {
 
-    });
+          //update user
+          user.update(req.body)
+            .exec(function(err) {
+              if (err) { res.send(err); }
+              return res.json({ message: 'User has been updated'});
+            });
+        } else {
+          return res.json({ message: 'User not found by id... no action performed'});
+        }
+      });
     })
 
     //delete method for removing a user from our database
     .delete(function(req, res) {
-    //selects the user by its ID, then removes it.
-    User.remove({ _id: req.params.user_id }, function(err, user) {
-      if (err) { res.send(err); }
-      res.json({ message: 'User has been deleted' })
-    })
+      User.findById(req.user._id)
+        .exec(function (err, user) {
+          if (!user._id.equals(req.user._id)) return res.json({ message: 'Users do not match'});
+          //selects the user by its ID, then removes it.
+          User.remove({ _id: req.params.user_id }, function(err, user) {
+            if (err) { res.send(err); }
+            return res.json({ message: 'User has been deleted' })
+          })
+        })
   });
 
   router.route("/follow/:project_id").post(function(req, res) {
-
-    // if user is not logged in reject
-    if (!req.user) {
-      return res.json({ message: "user does not exist" });
-    }
 
     const { _id: user_id } = req.user;
     const { project_id } = req.params;


### PR DESCRIPTION
Created a middleware for all  api routes so that get requests are excluded but put/post/delete requests all now require being logged in.

Also changed the put and delete requests to need the logged in users `_id` to match either the `project._id` or the `users._id`. Before it was possible for someone to simply request a project gets deleted without them necessarily owning the project.

One thing I also noticed, maybe an issue for later. Is that on the `PUT` requests you can clear all the details on a user / project document. We should limit them to only update certain fields, like keeping username the same for instance. Maybe an issue should be made for it in the future.